### PR TITLE
add pyqt5 as backend of vispy into requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ PyYAML>=5.1.1
 imgui[glfw]>=1.0.0 
 glfw>=1.8.3
 PyOpenGL>=3.1.0
+pyqt5>=5.8.1.1


### PR DESCRIPTION
I also met the problem reported in #21 and the reason should be the backend of vispy. So I suggest to add the pyqt5 with specific version requirement to the requirement list.