### PR TITLE
Additional command line options and new viewer to directly compare dataset labels 

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ To directly compare two sets of data, use the `compare.py` script. It will open 
 opengl visualization of the pointcloud labels.
 
 ```sh
-$ ./compare.py --sequence 00 --dataset_a /path/to/dataset_a/ --dataset_a /path/to/kitti/dataset_b/
+$ ./compare.py --sequence 00 --dataset_a /path/to/dataset_a/ --dataset_b /path/to/kitti/dataset_b/
 ```
 
 where:

--- a/README.md
+++ b/README.md
@@ -150,6 +150,23 @@ visualization of the labels with the visualization of your predictions:
 $ ./visualize.py --sequence 00 --dataset /path/to/kitti/dataset/ --predictions /path/to/your/predictions
 ```
 
+To directly compare two sets of data, use the `compare.py` script. It will open an interactive
+opengl visualization of the pointcloud labels.
+
+```sh
+$ ./compare.py --sequence 00 --dataset_a /path/to/dataset_a/ --dataset_a /path/to/kitti/dataset_b/
+```
+
+where:
+- `sequence` is the sequence to be accessed.
+- `dataset_a` is the path to a dataset in KITTI format where the `sequences` directory is.
+- `dataset_b` is the path to another dataset in KITTI format where the `sequences` directory is.
+
+Navigation:
+- `n` is next scan,
+- `b` is previous scan,
+- `esc` or `q` exits.
+
 #### Voxel Grids for Semantic Scene Completion
 
 To visualize the data, use the `visualize_voxels.py` script. It will open an interactive

--- a/auxiliary/eval_np.py
+++ b/auxiliary/eval_np.py
@@ -141,7 +141,7 @@ class PanopticEval:
       pred_areas = np.array([counts_pred[id2idx_pred[id]] for id in pred_labels])
       intersections = counts_combo
       unions = gt_areas + pred_areas - intersections
-      ious = intersections.astype(np.float) / unions.astype(np.float)
+      ious = intersections.astype(float / unions.astype(float))
 
 
       tp_indexes = ious > 0.5

--- a/auxiliary/laserscan.py
+++ b/auxiliary/laserscan.py
@@ -208,13 +208,13 @@ class SemLaserScan(LaserScan):
     self.proj_sem_label = np.zeros((self.proj_H, self.proj_W),
                                    dtype=np.int32)              # [H,W]  label
     self.proj_sem_color = np.zeros((self.proj_H, self.proj_W, 3),
-                                   dtype=np.float)              # [H,W,3] color
+                                   dtype=float)              # [H,W,3] color
 
     # projection color with instance labels
     self.proj_inst_label = np.zeros((self.proj_H, self.proj_W),
                                     dtype=np.int32)              # [H,W]  label
     self.proj_inst_color = np.zeros((self.proj_H, self.proj_W, 3),
-                                    dtype=np.float)              # [H,W,3] color
+                                    dtype=float)              # [H,W,3] color
 
   def open_label(self, filename):
     """ Open raw scan and fill in attributes

--- a/auxiliary/laserscan.py
+++ b/auxiliary/laserscan.py
@@ -170,10 +170,9 @@ class SemLaserScan(LaserScan):
   """Class that contains LaserScan with x,y,z,r,sem_label,sem_color_label,inst_label,inst_color_label"""
   EXTENSIONS_LABEL = ['.label']
 
-  def __init__(self, nclasses, sem_color_dict=None, project=False, H=64, W=1024, fov_up=3.0, fov_down=-25.0):
+  def __init__(self, sem_color_dict=None, project=False, H=64, W=1024, fov_up=3.0, fov_down=-25.0):
     super(SemLaserScan, self).__init__(project, H, W, fov_up, fov_down)
     self.reset()
-    self.nclasses = nclasses         # number of classes
 
     # make semantic colors
     max_sem_key = 0

--- a/auxiliary/laserscancomp.py
+++ b/auxiliary/laserscancomp.py
@@ -2,37 +2,42 @@
 # This file is covered by the LICENSE file in the root of this project.
 
 from auxiliary.vispy_manager import VispyManager
+import numpy as np
 
-
-class LaserScanComp:
+class LaserScanComp(VispyManager):
   """Class that creates and handles a side-by-side pointcloud comparison"""
 
   def __init__(self, scans, scan_names, label_names, offset=0, images=True, link=False):
+    super().__init__(offset, len(scan_names[0]), images)
     self.scan_a_view = None
     self.scan_a_vis = None
     self.scan_b_view = None
     self.scan_b_vis = None
+    self.img_a_view = None
+    self.img_a_vis = None
+    self.img_b_view = None
+    self.img_b_vis = None
     self.scan_a, self.scan_b = scans
     self.scan_a_names, self.scan_b_names = scan_names
     self.label_a_names, self.label_b_names = label_names
-    self.offset = offset
-    self.total = len(self.scan_a_names)
-    self.images = images
     self.link = link
-    self.vispy_manager = VispyManager(self.key_press, self.draw)
     self.reset()
     self.update_scan()
 
   def reset(self):
-    """ Reset. """
-    # new canvas prepared for visualizing data
-    self.scan_a_view, self.scan_a_vis = self.vispy_manager.add_viewbox(0, 0)
-    self.scan_b_view, self.scan_b_vis = self.vispy_manager.add_viewbox(0, 1)
+    """prepares the canvas(es) for the visualizer"""
+    self.scan_a_view, self.scan_a_vis = super().add_viewbox(0, 0)
+    self.scan_b_view, self.scan_b_vis = super().add_viewbox(0, 1)
 
     if self.link:
       self.scan_a_view.camera.link(self.scan_b_view.camera)
 
+    if self.images:
+      self.img_a_view, self.img_a_vis = super().add_image_viewbox(0, 0)
+      self.img_b_view, self.img_b_vis = super().add_image_viewbox(1, 0)
+
   def update_scan(self):
+    """updates the scans, images and instances"""
     self.scan_a.open_scan(self.scan_a_names[self.offset])
     self.scan_a.open_label(self.label_a_names[self.offset])
     self.scan_a.colorize()
@@ -49,25 +54,9 @@ class LaserScanComp:
                           edge_color=self.scan_b.sem_label_color[..., ::-1],
                           size=1)
 
-  def key_press(self, event):
-    self.vispy_manager.block_key_press()
-    if event.key == 'N':
-      self.offset += 1
-      if self.offset >= self.total:
-        self.offset = 0
-      self.update_scan()
-    elif event.key == 'B':
-      self.offset -= 1
-      if self.offset < 0:
-        self.offset = self.total - 1
-      self.update_scan()
-    elif event.key == 'Q' or event.key == 'Escape':
-      self.vispy_manager.destroy()
-    pass
+    if self.images:
+      self.img_a_vis.set_data(self.scan_a.proj_sem_color[..., ::-1])
+      self.img_a_vis.update()
+      self.img_b_vis.set_data(self.scan_b.proj_sem_color[..., ::-1])
+      self.img_b_vis.update()
 
-  def draw(self, event):
-    if self.vispy_manager.key_press_blocked():
-      self.vispy_manager.unblock_key_press()
-
-  def run(self):
-    self.vispy_manager.run()

--- a/auxiliary/laserscancomp.py
+++ b/auxiliary/laserscancomp.py
@@ -7,16 +7,24 @@ import numpy as np
 class LaserScanComp(VispyManager):
   """Class that creates and handles a side-by-side pointcloud comparison"""
 
-  def __init__(self, scans, scan_names, label_names, offset=0, images=True, link=False):
-    super().__init__(offset, len(scan_names[0]), images)
+  def __init__(self, scans, scan_names, label_names, offset=0, images=True, instances=False, link=False):
+    super().__init__(offset, len(scan_names[0]), images, instances)
     self.scan_a_view = None
     self.scan_a_vis = None
     self.scan_b_view = None
     self.scan_b_vis = None
+    self.inst_a_view = None
+    self.inst_a_vis = None
+    self.inst_b_view = None
+    self.inst_b_vis = None
     self.img_a_view = None
     self.img_a_vis = None
     self.img_b_view = None
     self.img_b_vis = None
+    self.img_inst_a_view = None
+    self.img_inst_a_vis = None
+    self.img_inst_b_view = None
+    self.img_inst_b_vis = None
     self.scan_a, self.scan_b = scans
     self.scan_a_names, self.scan_b_names = scan_names
     self.label_a_names, self.label_b_names = label_names
@@ -36,6 +44,18 @@ class LaserScanComp(VispyManager):
       self.img_a_view, self.img_a_vis = super().add_image_viewbox(0, 0)
       self.img_b_view, self.img_b_vis = super().add_image_viewbox(1, 0)
 
+      if self.instances:
+        self.img_inst_a_view, self.img_inst_a_vis = super().add_image_viewbox(2, 0)
+        self.img_inst_b_view, self.img_inst_b_vis = super().add_image_viewbox(3, 0)
+
+    if self.instances:
+      self.inst_a_view, self.inst_a_vis = super().add_viewbox(1, 0)
+      self.inst_b_view, self.inst_b_vis = super().add_viewbox(1, 1)
+
+      if self.link:
+        self.scan_a_view.camera.link(self.inst_a_view.camera)
+        self.inst_a_view.camera.link(self.inst_b_view.camera)
+
   def update_scan(self):
     """updates the scans, images and instances"""
     self.scan_a.open_scan(self.scan_a_names[self.offset])
@@ -54,9 +74,25 @@ class LaserScanComp(VispyManager):
                           edge_color=self.scan_b.sem_label_color[..., ::-1],
                           size=1)
 
+    if self.instances:
+      self.inst_a_vis.set_data(self.scan_a.points,
+                               face_color=self.scan_a.inst_label_color[..., ::-1],
+                               edge_color=self.scan_a.inst_label_color[..., ::-1],
+                               size=1)
+      self.inst_b_vis.set_data(self.scan_b.points,
+                               face_color=self.scan_b.inst_label_color[..., ::-1],
+                               edge_color=self.scan_b.inst_label_color[..., ::-1],
+                               size=1)
+
     if self.images:
       self.img_a_vis.set_data(self.scan_a.proj_sem_color[..., ::-1])
       self.img_a_vis.update()
       self.img_b_vis.set_data(self.scan_b.proj_sem_color[..., ::-1])
       self.img_b_vis.update()
+
+      if self.instances:
+        self.img_inst_a_vis.set_data(self.scan_a.proj_inst_color[..., ::-1])
+        self.img_inst_a_vis.update()
+        self.img_inst_b_vis.set_data(self.scan_b.proj_inst_color[..., ::-1])
+        self.img_inst_b_vis.update()
 

--- a/auxiliary/laserscancomp.py
+++ b/auxiliary/laserscancomp.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python3
+# This file is covered by the LICENSE file in the root of this project.
+
+from auxiliary.vispy_manager import VispyManager
+
+
+class LaserScanComp:
+  """Class that creates and handles a side-by-side pointcloud comparison"""
+
+  def __init__(self, scans, scan_names, label_names, offset=0, images=True, link=False):
+    self.scan_a_view = None
+    self.scan_a_vis = None
+    self.scan_b_view = None
+    self.scan_b_vis = None
+    self.scan_a, self.scan_b = scans
+    self.scan_a_names, self.scan_b_names = scan_names
+    self.label_a_names, self.label_b_names = label_names
+    self.offset = offset
+    self.total = len(self.scan_a_names)
+    self.images = images
+    self.link = link
+    self.vispy_manager = VispyManager(self.key_press, self.draw)
+    self.reset()
+    self.update_scan()
+
+  def reset(self):
+    """ Reset. """
+    # new canvas prepared for visualizing data
+    self.scan_a_view, self.scan_a_vis = self.vispy_manager.add_viewbox(0, 0)
+    self.scan_b_view, self.scan_b_vis = self.vispy_manager.add_viewbox(0, 1)
+
+    if self.link:
+      self.scan_a_view.camera.link(self.scan_b_view.camera)
+
+  def update_scan(self):
+    self.scan_a.open_scan(self.scan_a_names[self.offset])
+    self.scan_a.open_label(self.label_a_names[self.offset])
+    self.scan_a.colorize()
+    self.scan_a_vis.set_data(self.scan_a.points,
+                          face_color=self.scan_a.sem_label_color[..., ::-1],
+                          edge_color=self.scan_a.sem_label_color[..., ::-1],
+                          size=1)
+
+    self.scan_b.open_scan(self.scan_b_names[self.offset])
+    self.scan_b.open_label(self.label_b_names[self.offset])
+    self.scan_b.colorize()
+    self.scan_b_vis.set_data(self.scan_b.points,
+                          face_color=self.scan_b.sem_label_color[..., ::-1],
+                          edge_color=self.scan_b.sem_label_color[..., ::-1],
+                          size=1)
+
+  def key_press(self, event):
+    self.vispy_manager.block_key_press()
+    if event.key == 'N':
+      self.offset += 1
+      if self.offset >= self.total:
+        self.offset = 0
+      self.update_scan()
+    elif event.key == 'B':
+      self.offset -= 1
+      if self.offset < 0:
+        self.offset = self.total - 1
+      self.update_scan()
+    elif event.key == 'Q' or event.key == 'Escape':
+      self.vispy_manager.destroy()
+    pass
+
+  def draw(self, event):
+    if self.vispy_manager.key_press_blocked():
+      self.vispy_manager.unblock_key_press()
+
+  def run(self):
+    self.vispy_manager.run()

--- a/auxiliary/laserscancomp.py
+++ b/auxiliary/laserscancomp.py
@@ -8,7 +8,7 @@ class LaserScanComp(VispyManager):
   """Class that creates and handles a side-by-side pointcloud comparison"""
 
   def __init__(self, scans, scan_names, label_names, offset=0, images=True, instances=False, link=False):
-    super().__init__(offset, len(scan_names[0]), images, instances)
+    super().__init__(offset, len(scan_names), images, instances)
     self.scan_a_view = None
     self.scan_a_vis = None
     self.scan_b_view = None
@@ -26,7 +26,7 @@ class LaserScanComp(VispyManager):
     self.img_inst_b_view = None
     self.img_inst_b_vis = None
     self.scan_a, self.scan_b = scans
-    self.scan_a_names, self.scan_b_names = scan_names
+    self.scan_names = scan_names
     self.label_a_names, self.label_b_names = label_names
     self.link = link
     self.reset()
@@ -58,7 +58,7 @@ class LaserScanComp(VispyManager):
 
   def update_scan(self):
     """updates the scans, images and instances"""
-    self.scan_a.open_scan(self.scan_a_names[self.offset])
+    self.scan_a.open_scan(self.scan_names[self.offset])
     self.scan_a.open_label(self.label_a_names[self.offset])
     self.scan_a.colorize()
     self.scan_a_vis.set_data(self.scan_a.points,
@@ -66,7 +66,7 @@ class LaserScanComp(VispyManager):
                           edge_color=self.scan_a.sem_label_color[..., ::-1],
                           size=1)
 
-    self.scan_b.open_scan(self.scan_b_names[self.offset])
+    self.scan_b.open_scan(self.scan_names[self.offset])
     self.scan_b.open_label(self.label_b_names[self.offset])
     self.scan_b.colorize()
     self.scan_b_vis.set_data(self.scan_b.points,

--- a/auxiliary/laserscanvis.py
+++ b/auxiliary/laserscanvis.py
@@ -130,7 +130,6 @@ class LaserScanVis:
     color_range = sm.to_rgba(np.linspace(0, 1, 256), bytes=True)[:, 2::-1]
 
     return color_range.reshape(256, 3).astype(np.float32) / 255.0
-
   def update_scan(self):
     # first open data
     self.scan.open_scan(self.scan_names[self.offset])

--- a/auxiliary/laserscanvis.py
+++ b/auxiliary/laserscanvis.py
@@ -12,7 +12,7 @@ class LaserScanVis:
   """Class that creates and handles a visualizer for a pointcloud"""
 
   def __init__(self, scan, scan_names, label_names, offset=0,
-               semantics=True, instances=False):
+               semantics=True, instances=False, images=True, link=False):
     self.scan = scan
     self.scan_names = scan_names
     self.label_names = label_names
@@ -20,6 +20,8 @@ class LaserScanVis:
     self.total = len(self.scan_names)
     self.semantics = semantics
     self.instances = instances
+    self.images = images
+    self.link = link
     # sanity check
     if not self.semantics and self.instances:
       print("Instances are only allowed in when semantics=True")
@@ -60,7 +62,8 @@ class LaserScanVis:
       self.sem_view.camera = 'turntable'
       self.sem_view.add(self.sem_vis)
       visuals.XYZAxis(parent=self.sem_view.scene)
-      # self.sem_view.camera.link(self.scan_view.camera)
+      if self.link:
+        self.sem_view.camera.link(self.scan_view.camera)
 
     if self.instances:
       print("Using instances in visualizer")
@@ -71,40 +74,41 @@ class LaserScanVis:
       self.inst_view.camera = 'turntable'
       self.inst_view.add(self.inst_vis)
       visuals.XYZAxis(parent=self.inst_view.scene)
-      # self.inst_view.camera.link(self.scan_view.camera)
-
-    # img canvas size
-    self.multiplier = 1
-    self.canvas_W = 1024
-    self.canvas_H = 64
-    if self.semantics:
-      self.multiplier += 1
-    if self.instances:
-      self.multiplier += 1
-
-    # new canvas for img
-    self.img_canvas = SceneCanvas(keys='interactive', show=True,
-                                  size=(self.canvas_W, self.canvas_H * self.multiplier))
-    # grid
-    self.img_grid = self.img_canvas.central_widget.add_grid()
-    # interface (n next, b back, q quit, very simple)
-    self.img_canvas.events.key_press.connect(self.key_press)
-    self.img_canvas.events.draw.connect(self.draw)
+      if self.link:
+        self.inst_view.camera.link(self.scan_view.camera)
 
     # add a view for the depth
-    self.img_view = vispy.scene.widgets.ViewBox(
-        border_color='white', parent=self.img_canvas.scene)
-    self.img_grid.add_widget(self.img_view, 0, 0)
-    self.img_vis = visuals.Image(cmap='viridis')
-    self.img_view.add(self.img_vis)
+    if self.images:
+      # img canvas size
+      self.multiplier = 1
+      self.canvas_W = 1024
+      self.canvas_H = 64
+      if self.semantics:
+        self.multiplier += 1
+      if self.instances:
+        self.multiplier += 1
 
-    # add semantics
-    if self.semantics:
-      self.sem_img_view = vispy.scene.widgets.ViewBox(
+      # new canvas for img
+      self.img_canvas = SceneCanvas(keys='interactive', show=True,
+                                    size=(self.canvas_W, self.canvas_H * self.multiplier))
+      # grid
+      self.img_grid = self.img_canvas.central_widget.add_grid()
+      # interface (n next, b back, q quit, very simple)
+      self.img_canvas.events.key_press.connect(self.key_press)
+      self.img_canvas.events.draw.connect(self.draw)
+      self.img_view = vispy.scene.widgets.ViewBox(
           border_color='white', parent=self.img_canvas.scene)
-      self.img_grid.add_widget(self.sem_img_view, 1, 0)
-      self.sem_img_vis = visuals.Image(cmap='viridis')
-      self.sem_img_view.add(self.sem_img_vis)
+      self.img_grid.add_widget(self.img_view, 0, 0)
+      self.img_vis = visuals.Image(cmap='viridis')
+      self.img_view.add(self.img_vis)
+
+      # add image semantics
+      if self.semantics:
+        self.sem_img_view = vispy.scene.widgets.ViewBox(
+            border_color='white', parent=self.img_canvas.scene)
+        self.img_grid.add_widget(self.sem_img_view, 1, 0)
+        self.sem_img_vis = visuals.Image(cmap='viridis')
+        self.sem_img_view.add(self.sem_img_vis)
 
     # add instances
     if self.instances:
@@ -113,6 +117,8 @@ class LaserScanVis:
       self.img_grid.add_widget(self.inst_img_view, 2, 0)
       self.inst_img_vis = visuals.Image(cmap='viridis')
       self.inst_img_view.add(self.inst_img_vis)
+      if self.link:
+        self.inst_view.camera.link(self.scan_view.camera)
 
   def get_mpl_colormap(self, cmap_name):
     cmap = plt.get_cmap(cmap_name)
@@ -135,7 +141,8 @@ class LaserScanVis:
     # then change names
     title = "scan " + str(self.offset)
     self.canvas.title = title
-    self.img_canvas.title = title
+    if self.images:
+      self.img_canvas.title = title
 
     # then do all the point cloud stuff
 
@@ -170,31 +177,33 @@ class LaserScanVis:
                              edge_color=self.scan.inst_label_color[..., ::-1],
                              size=1)
 
-    # now do all the range image stuff
-    # plot range image
-    data = np.copy(self.scan.proj_range)
-    # print(data[data > 0].max(), data[data > 0].min())
-    data[data > 0] = data[data > 0]**(1 / power)
-    data[data < 0] = data[data > 0].min()
-    # print(data.max(), data.min())
-    data = (data - data[data > 0].min()) / \
-        (data.max() - data[data > 0].min())
-    # print(data.max(), data.min())
-    self.img_vis.set_data(data)
-    self.img_vis.update()
+    if self.images:
+      # now do all the range image stuff
+      # plot range image
+      data = np.copy(self.scan.proj_range)
+      # print(data[data > 0].max(), data[data > 0].min())
+      data[data > 0] = data[data > 0]**(1 / power)
+      data[data < 0] = data[data > 0].min()
+      # print(data.max(), data.min())
+      data = (data - data[data > 0].min()) / \
+          (data.max() - data[data > 0].min())
+      # print(data.max(), data.min())
+      self.img_vis.set_data(data)
+      self.img_vis.update()
 
-    if self.semantics:
-      self.sem_img_vis.set_data(self.scan.proj_sem_color[..., ::-1])
-      self.sem_img_vis.update()
+      if self.semantics:
+        self.sem_img_vis.set_data(self.scan.proj_sem_color[..., ::-1])
+        self.sem_img_vis.update()
 
-    if self.instances:
-      self.inst_img_vis.set_data(self.scan.proj_inst_color[..., ::-1])
-      self.inst_img_vis.update()
+      if self.instances:
+        self.inst_img_vis.set_data(self.scan.proj_inst_color[..., ::-1])
+        self.inst_img_vis.update()
 
   # interface
   def key_press(self, event):
     self.canvas.events.key_press.block()
-    self.img_canvas.events.key_press.block()
+    if self.images:
+      self.img_canvas.events.key_press.block()
     if event.key == 'N':
       self.offset += 1
       if self.offset >= self.total:
@@ -211,13 +220,14 @@ class LaserScanVis:
   def draw(self, event):
     if self.canvas.events.key_press.blocked():
       self.canvas.events.key_press.unblock()
-    if self.img_canvas.events.key_press.blocked():
+    if self.images and self.img_canvas.events.key_press.blocked():
       self.img_canvas.events.key_press.unblock()
 
   def destroy(self):
     # destroy the visualization
     self.canvas.close()
-    self.img_canvas.close()
+    if self.images:
+      self.img_canvas.close()
     vispy.app.quit()
 
   def run(self):

--- a/auxiliary/vispy_manager.py
+++ b/auxiliary/vispy_manager.py
@@ -7,10 +7,11 @@ from abc import ABC, abstractmethod
 import numpy as np
 
 class VispyManager(ABC):
-  def __init__(self, offset, total, images):
+  def __init__(self, offset, total, images, instances):
     self.canvas, self.grid = self.add_canvas('interactive', 'scan')
     self.offset = offset
     self.images = images
+    self.instances = instances
     self.n_images = 2
     self.img_canvas_W = 1024
     self.img_canvas_H = 64 * self.n_images

--- a/auxiliary/vispy_manager.py
+++ b/auxiliary/vispy_manager.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python3
+# This file is covered by the LICENSE file in the root of this project.
+
+import vispy
+from vispy.scene import visuals, SceneCanvas
+
+
+class VispyManager(object):
+  def __init__(self, key_press, draw):
+    self.canvas = SceneCanvas(keys='interactive', show=True)
+    self.canvas.events.key_press.connect(key_press)
+    self.canvas.events.draw.connect(draw)
+    self.grid = self.canvas.central_widget.add_grid()
+    self.destroyed = False
+
+  def block_key_press(self):
+    self.canvas.events.key_press.block()
+
+  def key_press_blocked(self):
+    return self.canvas.events.key_press.blocked()
+
+  def key_press_unblocked(self):
+    return not self.canvas.events.key_press.blocked()
+
+  def unblock_key_press(self):
+    self.canvas.events.key_press.unblock()
+
+  def add_viewbox(self, row, col, border_color='white'):
+    view = vispy.scene.widgets.ViewBox(border_color=border_color, parent=self.canvas.scene)
+    self.grid.add_widget(view, row, col)
+    vis = visuals.Markers()
+    view.camera = 'turntable'
+    view.add(vis)
+    visuals.XYZAxis(parent=view.scene)
+    return view, vis
+
+  def destroy(self):
+    self.canvas.close()
+    vispy.app.quit()
+    self.destroyed = True
+
+  def __del__(self):
+    if not self.destroyed:
+      self.destroy()
+
+  def run(self):
+    vispy.app.run()

--- a/compare.py
+++ b/compare.py
@@ -77,6 +77,14 @@ if __name__ == '__main__':
       ' that safety.'
       'Defaults to %(default)s',
   )
+  parser.add_argument(
+    '--color_learning_map',
+    dest='color_learning_map',
+    default=False,
+    required=False,
+    action='store_true',
+    help='Apply learning map to color map: visualize only classes that were trained on',
+  )
   FLAGS, unparsed = parser.parse_known_args()
 
   # print summary of what we will do
@@ -89,6 +97,7 @@ if __name__ == '__main__':
   print("do_instances", FLAGS.do_instances)
   print("link", FLAGS.link)
   print("ignore_safety", FLAGS.ignore_safety)
+  print("color_learning_map", FLAGS.color_learning_map)
   print("offset", FLAGS.offset)
   print("*" * 80)
 
@@ -150,9 +159,13 @@ if __name__ == '__main__':
 
   # create scans
   color_dict = CFG["color_map"]
-  nclasses = len(color_dict)
-  scan_a = SemLaserScan(nclasses, color_dict, project=True)
-  scan_b = SemLaserScan(nclasses, color_dict, project=True)
+  if FLAGS.color_learning_map:
+    learning_map_inv = CFG["learning_map_inv"]
+    learning_map = CFG["learning_map"]
+    color_dict = {key: color_dict[learning_map_inv[learning_map[key]]] for key, value in color_dict.items()}
+
+  scan_b = SemLaserScan(color_dict, project=True)
+  scan_a = SemLaserScan(color_dict, project=True)
 
   # create a visualizer
   images = not FLAGS.ignore_images

--- a/compare.py
+++ b/compare.py
@@ -44,6 +44,14 @@ if __name__ == '__main__':
       help='Visualize range image projections too. Defaults to %(default)s',
   )
   parser.add_argument(
+      '--do_instances', '-d',
+      dest='do_instances',
+      default=False,
+      required=False,
+      action='store_true',
+      help='Visualize instances too. Defaults to %(default)s',
+  )
+  parser.add_argument(
       '--link', '-l',
       dest='link',
       default=False,
@@ -79,6 +87,7 @@ if __name__ == '__main__':
   print("Config", FLAGS.config)
   print("Sequence", FLAGS.sequence)
   print("ignore_images", FLAGS.ignore_images)
+  print("do_instances", FLAGS.do_instances)
   print("link", FLAGS.link)
   print("ignore_safety", FLAGS.ignore_safety)
   print("offset", FLAGS.offset)
@@ -158,7 +167,7 @@ if __name__ == '__main__':
   vis = LaserScanComp(scans=(scan_a, scan_b),
                      scan_names=(scan_a_names, scan_b_names),
                      label_names=(label_a_names, label_b_names),
-                     offset=FLAGS.offset, images=images, link=FLAGS.link)
+                     offset=FLAGS.offset, images=images, instances=FLAGS.do_instances, link=FLAGS.link)
 
   # print instructions
   print("To navigate:")

--- a/compare.py
+++ b/compare.py
@@ -1,0 +1,172 @@
+#!/usr/bin/env python3
+# This file is covered by the LICENSE file in the root of this project.
+
+import argparse
+import os
+import yaml
+from auxiliary.laserscan import LaserScan, SemLaserScan
+from auxiliary.laserscancomp import LaserScanComp
+
+if __name__ == '__main__':
+  parser = argparse.ArgumentParser("./compare.py")
+  parser.add_argument(
+      '--dataset_a',
+      type=str,
+      required=True,
+      help='Dataset A to visualize. No Default',
+  )
+  parser.add_argument(
+      '--dataset_b',
+      type=str,
+      required=True,
+      help='Dataset B to visualize. No Default',
+  )
+  parser.add_argument(
+      '--config', '-c',
+      type=str,
+      required=False,
+      default="config/semantic-kitti.yaml",
+      help='Dataset config file. Defaults to %(default)s',
+  )
+  parser.add_argument(
+      '--sequence', '-s',
+      type=str,
+      default="00",
+      required=False,
+      help='Sequence to visualize. Defaults to %(default)s',
+  )
+  parser.add_argument(
+      '--ignore_images', '-r',
+      dest='ignore_images',
+      default=False,
+      required=False,
+      action='store_true',
+      help='Visualize range image projections too. Defaults to %(default)s',
+  )
+  parser.add_argument(
+      '--link', '-l',
+      dest='link',
+      default=False,
+      required=False,
+      action='store_true',
+      help='Link viewpoint changes across windows. Defaults to %(default)s',
+  )
+  parser.add_argument(
+      '--offset',
+      type=int,
+      default=0,
+      required=False,
+      help='Sequence to start. Defaults to %(default)s',
+  )
+  parser.add_argument(
+      '--ignore_safety',
+      dest='ignore_safety',
+      default=False,
+      required=False,
+      action='store_true',
+      help='Normally you want the number of labels and ptcls to be the same,'
+      ', but if you are not done inferring this is not the case, so this disables'
+      ' that safety.'
+      'Defaults to %(default)s',
+  )
+  FLAGS, unparsed = parser.parse_known_args()
+
+  # print summary of what we will do
+  print("*" * 80)
+  print("INTERFACE:")
+  print("Dataset A", FLAGS.dataset_a)
+  print("Dataset B", FLAGS.dataset_b)
+  print("Config", FLAGS.config)
+  print("Sequence", FLAGS.sequence)
+  print("ignore_images", FLAGS.ignore_images)
+  print("link", FLAGS.link)
+  print("ignore_safety", FLAGS.ignore_safety)
+  print("offset", FLAGS.offset)
+  print("*" * 80)
+
+  # open config file
+  try:
+    print("Opening config file %s" % FLAGS.config)
+    CFG = yaml.safe_load(open(FLAGS.config, 'r'))
+  except Exception as e:
+    print(e)
+    print("Error opening yaml file.")
+    quit()
+
+  # fix sequence name
+  FLAGS.sequence = '{0:02d}'.format(int(FLAGS.sequence))
+
+  # does sequence folder exist?
+  scan_a_paths = os.path.join(FLAGS.dataset_a, "sequences", FLAGS.sequence, "velodyne")
+  scan_b_paths = os.path.join(FLAGS.dataset_b, "sequences", FLAGS.sequence, "velodyne")
+
+  if os.path.isdir(scan_a_paths):
+    print("Sequence folder a exists! Using sequence from %s" % scan_a_paths)
+  else:
+    print("Sequence folder a doesn't exist! Exiting...")
+    quit()
+
+  if os.path.isdir(scan_b_paths):
+    print("Sequence folder b exists! Using sequence from %s" % scan_b_paths)
+  else:
+    print("Sequence folder b doesn't exist! Exiting...")
+    quit()
+
+  # populate the pointclouds
+  scan_a_names = [os.path.join(dp, f) for dp, dn, fn in os.walk(os.path.expanduser(scan_a_paths)) for f in fn]
+  scan_a_names.sort()
+
+  scan_b_names = [os.path.join(dp, f) for dp, dn, fn in os.walk(os.path.expanduser(scan_b_paths)) for f in fn]
+  scan_b_names.sort()
+
+  # does sequence folder exist?
+  label_a_paths = os.path.join(FLAGS.dataset_a, "sequences", FLAGS.sequence, "labels")
+  label_b_paths = os.path.join(FLAGS.dataset_b, "sequences", FLAGS.sequence, "labels")
+
+  assert(len(scan_a_names) == len(scan_b_names))
+  assert(len(label_a_paths) == len(label_b_paths))
+
+  if os.path.isdir(label_a_paths):
+    print("Labels folder a exists! Using labels from %s" % label_a_paths)
+  else:
+    print("Labels folder a doesn't exist! Exiting...")
+    quit()
+
+  if os.path.isdir(label_b_paths):
+    print("Labels folder b exists! Using labels from %s" % label_b_paths)
+  else:
+    print("Labels folder b doesn't exist! Exiting...")
+    quit()
+
+  # populate the pointclouds
+  label_a_names = [os.path.join(dp, f) for dp, dn, fn in os.walk(os.path.expanduser(label_a_paths)) for f in fn]
+  label_a_names.sort()
+  label_b_names = [os.path.join(dp, f) for dp, dn, fn in os.walk(os.path.expanduser(label_b_paths)) for f in fn]
+  label_b_names.sort()
+
+  # check that there are same amount of labels and scans
+  if not FLAGS.ignore_safety:
+    assert(len(label_a_names) == len(scan_a_names))
+    assert(len(label_b_names) == len(scan_b_names))
+
+  # create scans
+  color_dict = CFG["color_map"]
+  nclasses = len(color_dict)
+  scan_a = SemLaserScan(nclasses, color_dict, project=True)
+  scan_b = SemLaserScan(nclasses, color_dict, project=True)
+
+  # create a visualizer
+  images = not FLAGS.ignore_images
+  vis = LaserScanComp(scans=(scan_a, scan_b),
+                     scan_names=(scan_a_names, scan_b_names),
+                     label_names=(label_a_names, label_b_names),
+                     offset=FLAGS.offset, images=images, link=FLAGS.link)
+
+  # print instructions
+  print("To navigate:")
+  print("\tb: back (previous scan)")
+  print("\tn: next (next scan)")
+  print("\tq: quit (exit program)")
+
+  # run the visualizer
+  vis.run()

--- a/compare.py
+++ b/compare.py
@@ -123,9 +123,6 @@ if __name__ == '__main__':
   label_a_paths = os.path.join(FLAGS.dataset_a, "sequences", FLAGS.sequence, "labels")
   label_b_paths = os.path.join(FLAGS.dataset_b, "sequences", FLAGS.sequence, "labels")
 
-  assert(len(scan_a_names) == len(scan_b_names))
-  assert(len(label_a_paths) == len(label_b_paths))
-
   if os.path.isdir(label_a_paths):
     print("Labels folder a exists! Using labels from %s" % label_a_paths)
   else:
@@ -146,8 +143,9 @@ if __name__ == '__main__':
 
   # check that there are same amount of labels and scans
   if not FLAGS.ignore_safety:
-    assert(len(label_a_names) == len(scan_a_names))
-    assert(len(label_b_names) == len(scan_b_names))
+    assert len(label_a_names) == len(scan_a_names)
+    assert len(label_b_names) == len(scan_b_names)
+    assert len(scan_a_names) == len(scan_b_names)
 
   # create scans
   color_dict = CFG["color_map"]

--- a/config/semantic-kitti-coarse.yaml
+++ b/config/semantic-kitti-coarse.yaml
@@ -1,0 +1,189 @@
+# This file is covered by the LICENSE file in the root of this project.
+labels: 
+  0 : "unlabeled"
+  1 : "outlier"
+  10: "car"
+  11: "bicycle"
+  13: "bus"
+  15: "motorcycle"
+  16: "on-rails"
+  18: "truck"
+  20: "other-vehicle"
+  30: "person"
+  31: "bicyclist"
+  32: "motorcyclist"
+  40: "road"
+  44: "parking"
+  48: "sidewalk"
+  49: "other-ground"
+  50: "building"
+  51: "fence"
+  52: "other-structure"
+  60: "lane-marking"
+  70: "vegetation"
+  71: "trunk"
+  72: "terrain"
+  80: "pole"
+  81: "traffic-sign"
+  99: "other-object"
+  252: "moving-car"
+  253: "moving-bicyclist"
+  254: "moving-person"
+  255: "moving-motorcyclist"
+  256: "moving-on-rails"
+  257: "moving-bus"
+  258: "moving-truck"
+  259: "moving-other-vehicle"
+color_map: # bgr
+  0 : [0, 0, 0]
+  1 : [0, 0, 255]
+  10: [245, 150, 100]
+  11: [245, 230, 100]
+  13: [250, 80, 100]
+  15: [150, 60, 30]
+  16: [255, 0, 0]
+  18: [180, 30, 80]
+  20: [255, 0, 0]
+  30: [30, 30, 255]
+  31: [200, 40, 255]
+  32: [90, 30, 150]
+  40: [255, 0, 255]
+  44: [255, 150, 255]
+  48: [75, 0, 75]
+  49: [75, 0, 175]
+  50: [0, 200, 255]
+  51: [50, 120, 255]
+  52: [0, 150, 255]
+  60: [170, 255, 150]
+  70: [0, 175, 0]
+  71: [0, 60, 135]
+  72: [80, 240, 150]
+  80: [150, 240, 255]
+  81: [0, 0, 255]
+  99: [255, 255, 50]
+  252: [245, 150, 100]
+  256: [255, 0, 0]
+  253: [200, 40, 255]
+  254: [30, 30, 255]
+  255: [90, 30, 150]
+  257: [250, 80, 100]
+  258: [180, 30, 80]
+  259: [255, 0, 0]
+content: # as a ratio with the total number of points
+  0: 0.018889854628292943
+  1: 0.0002937197336781505
+  10: 0.040818519255974316
+  11: 0.00016609538710764618
+  13: 2.7879693665067774e-05
+  15: 0.00039838616015114444
+  16: 0.0
+  18: 0.0020633612104619787
+  20: 0.0016218197275284021
+  30: 0.00017698551338515307
+  31: 1.1065903904919655e-08
+  32: 5.532951952459828e-09
+  40: 0.1987493871255525
+  44: 0.014717169549888214
+  48: 0.14392298360372
+  49: 0.0039048553037472045
+  50: 0.1326861944777486
+  51: 0.0723592229456223
+  52: 0.002395131480328884
+  60: 4.7084144280367186e-05
+  70: 0.26681502148037506
+  71: 0.006035012012626033
+  72: 0.07814222006271769
+  80: 0.002855498193863172
+  81: 0.0006155958086189918
+  99: 0.009923127583046915
+  252: 0.001789309418528068
+  253: 0.00012709999297008662
+  254: 0.00016059776092534436
+  255: 3.745553104802113e-05
+  256: 0.0
+  257: 0.00011351574470342043
+  258: 0.00010157861367183268
+  259: 4.3840131989471124e-05
+# classes that are indistinguishable from single scan or inconsistent in
+# ground truth are mapped to their closest equivalent
+learning_map: # according to COLA
+  0: 0
+  1: 0
+  10: 3
+  11: 3
+  13: 3
+  15: 3
+  16: 3
+  18: 3
+  20: 3
+  30: 5
+  31: 5
+  32: 5
+  40: 1
+  44: 1
+  48: 8
+  49: 8
+  50: 2
+  51: 2
+  52: 2
+  60: 1
+  70: 4
+  71: 4
+  72: 4
+  80: 7
+  81: 7
+  99: 0
+  252: 3
+  253: 3
+  254: 5
+  255: 5
+  256: 3
+  257: 5
+  258: 3
+  259: 3
+learning_map_inv: # inverse of previous map
+  0: 0      # "unlabeled", and others ignored
+  1: 40     # "drivable ground: parking, road (40)"
+  2: 50     # "structure: fence, building (50)"
+  3: 10     # "vehicle: motorcycle, car (10), bicycle, truck, other vehicles"
+  4: 70     # "nature: trunk, vegetation (70), terrain"
+  5: 30     # "living-being: person (30), bicyclist, motorcyclist"
+  6: 0      # "dynamic object"
+  7: 80     # "static-object: pole (80), sign"
+  8: 48     # other ground: sidewalk (48), other ground
+learning_ignore: # Ignore classes
+  0: True      # "unlabeled", and others ignored
+  1: False    # "drivable ground: parking, road (40)"
+  2: False     # "structure: fence, building (50)"
+  3: False     # "vehicle: motorcycle, car (10), bicycle, truck, other vehicles"
+  4: False     # "nature: trunk, vegetation (70), terrain"
+  5: False     # "living-being: person (30), bicyclist, motorcyclist"
+  6: True      # "dynamic object"
+  7: False     # "static-object: pole (80), sign"
+  8: False     # other ground: sidewalk (48), other ground
+split: # sequence numbers
+  train:
+    - 0
+    - 1
+    - 2
+    - 3
+    - 4
+    - 5
+    - 6
+    - 7
+    - 9
+    - 10
+  valid:
+    - 8
+  test:
+    - 11
+    - 12
+    - 13
+    - 14
+    - 15
+    - 16
+    - 17
+    - 18
+    - 19
+    - 20
+    - 21

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 matplotlib>=2.2.3
 vispy>=0.5.3
 torch>=1.1.0
-numpy>=1.14.0
+numpy>=1.24.0
 PyYAML>=5.1.1
 imgui[glfw]>=1.0.0 
 glfw>=1.8.3

--- a/visualize.py
+++ b/visualize.py
@@ -51,8 +51,25 @@ if __name__ == '__main__':
       '--do_instances', '-di',
       dest='do_instances',
       default=False,
+      required=False,
       action='store_true',
       help='Visualize instances too. Defaults to %(default)s',
+  )
+  parser.add_argument(
+      '--ignore_images', '-r',
+      dest='ignore_images',
+      default=False,
+      required=False,
+      action='store_true',
+      help='Visualize range image projections too. Defaults to %(default)s',
+  )
+  parser.add_argument(
+      '--link', '-l',
+      dest='link',
+      default=False,
+      required=False,
+      action='store_true',
+      help='Link viewpoint changes across windows. Defaults to %(default)s',
   )
   parser.add_argument(
       '--offset',
@@ -65,6 +82,7 @@ if __name__ == '__main__':
       '--ignore_safety',
       dest='ignore_safety',
       default=False,
+      required=False,
       action='store_true',
       help='Normally you want the number of labels and ptcls to be the same,'
       ', but if you are not done inferring this is not the case, so this disables'
@@ -82,6 +100,8 @@ if __name__ == '__main__':
   print("Predictions", FLAGS.predictions)
   print("ignore_semantics", FLAGS.ignore_semantics)
   print("do_instances", FLAGS.do_instances)
+  print("ignore_images", FLAGS.ignore_images)
+  print("link", FLAGS.link)
   print("ignore_safety", FLAGS.ignore_safety)
   print("offset", FLAGS.offset)
   print("*" * 80)
@@ -145,13 +165,14 @@ if __name__ == '__main__':
   # create a visualizer
   semantics = not FLAGS.ignore_semantics
   instances = FLAGS.do_instances
+  images = not FLAGS.ignore_images
   if not semantics:
     label_names = None
   vis = LaserScanVis(scan=scan,
                      scan_names=scan_names,
                      label_names=label_names,
                      offset=FLAGS.offset,
-                     semantics=semantics, instances=instances and semantics)
+                     semantics=semantics, instances=instances and semantics, images=images, link=FLAGS.link)
 
   # print instructions
   print("To navigate:")

--- a/visualize.py
+++ b/visualize.py
@@ -48,7 +48,7 @@ if __name__ == '__main__':
       'Defaults to %(default)s',
   )
   parser.add_argument(
-      '--do_instances', '-di',
+      '--do_instances', '-d',
       dest='do_instances',
       default=False,
       required=False,

--- a/visualize_mos.py
+++ b/visualize_mos.py
@@ -72,6 +72,14 @@ if __name__ == '__main__':
       ' that safety.'
       'Defaults to %(default)s',
   )
+  parser.add_argument(
+    '--color_learning_map',
+    dest='color_learning_map',
+    default=False,
+    required=False,
+    action='store_true',
+    help='Apply learning map to color map: visualize only classes that were trained on',
+  )
   FLAGS, unparsed = parser.parse_known_args()
 
   # print summary of what we will do
@@ -84,6 +92,7 @@ if __name__ == '__main__':
   print("ignore_semantics", FLAGS.ignore_semantics)
   print("do_instances", FLAGS.do_instances)
   print("ignore_safety", FLAGS.ignore_safety)
+  print("color_learning_map", FLAGS.color_learning_map)
   print("offset", FLAGS.offset)
   print("*" * 80)
 
@@ -141,8 +150,12 @@ if __name__ == '__main__':
     scan = LaserScan(project=True)  # project all opened scans to spheric proj
   else:
     color_dict = CFG["color_map"]
-    nclasses = len(color_dict)
-    scan = SemLaserScan(nclasses, color_dict, project=True)
+    if FLAGS.color_learning_map:
+      learning_map_inv = CFG["learning_map_inv"]
+      learning_map = CFG["learning_map"]
+      color_dict = {key:color_dict[learning_map_inv[learning_map[key]]] for key, value in color_dict.items()}
+
+    scan = SemLaserScan(color_dict, project=True)
 
   # create a visualizer
   semantics = not FLAGS.ignore_semantics


### PR DESCRIPTION
This PR adds three changes:

* bumps numpy version to mitigate `np.float32` deprecation
* Adds option to link viewpoint changes across views
* Adds new visualizer (`compare.py`) to directly compare two datasets and their labels. Example use case: directly compare output of two semantic labeling nns, manual labeling comparisons

At this point, I'd welcome feedback from you before continuing:

1. I took the liberty to compartmentalize some parts of often used code, in `vispy_manager.py` and used it in the new compare viewer. Is this style of refactoring something you're interested in for the existing viewers? 
2. I wrote a separate comparison viewer, because the amount of command line options were starting to get quite cluttered, in my opinion. Do you agree with this decision?
3. Also, I'm not sure how to handle instances and images in the comparison viewer. Should they be made optional with command line argument, similar to `visualize.py`?

Thanks