### PR TITLE
Disable antialiasing

### DIFF
--- a/auxiliary/laserscanvis.py
+++ b/auxiliary/laserscanvis.py
@@ -48,7 +48,7 @@ class LaserScanVis:
     self.scan_view = vispy.scene.widgets.ViewBox(
         border_color='white', parent=self.canvas.scene)
     self.grid.add_widget(self.scan_view, 0, 0)
-    self.scan_vis = visuals.Markers()
+    self.scan_vis = visuals.Markers(antialias=0)
     self.scan_view.camera = 'turntable'
     self.scan_view.add(self.scan_vis)
     visuals.XYZAxis(parent=self.scan_view.scene)
@@ -58,7 +58,7 @@ class LaserScanVis:
       self.sem_view = vispy.scene.widgets.ViewBox(
           border_color='white', parent=self.canvas.scene)
       self.grid.add_widget(self.sem_view, 0, 1)
-      self.sem_vis = visuals.Markers()
+      self.sem_vis = visuals.Markers(antialias=0)
       self.sem_view.camera = 'turntable'
       self.sem_view.add(self.sem_vis)
       visuals.XYZAxis(parent=self.sem_view.scene)
@@ -70,7 +70,7 @@ class LaserScanVis:
       self.inst_view = vispy.scene.widgets.ViewBox(
           border_color='white', parent=self.canvas.scene)
       self.grid.add_widget(self.inst_view, 0, 2)
-      self.inst_vis = visuals.Markers()
+      self.inst_vis = visuals.Markers(antialias=0)
       self.inst_view.camera = 'turntable'
       self.inst_view.add(self.inst_vis)
       visuals.XYZAxis(parent=self.inst_view.scene)


### PR DESCRIPTION
I saw that there are some strange borders around the points, probably caused by a bug in the antialiasing as reported [here](https://github.com/vispy/vispy/issues/1583).

The only way I found to fix this is to turn off antialiasing.

Before this PR:
![image](https://github.com/user-attachments/assets/faf0c2db-a44b-4137-844d-4777c93ed851)


With this PR:
![image](https://github.com/user-attachments/assets/6c7eec50-4069-41cb-b2a2-a84c3b14fb2a)


The effect becomes even more visible when manually setting the background to white:

Before this PR:
![image](https://github.com/user-attachments/assets/e57a8de0-7910-4c02-9bb4-704bf94646f4)


With this PR:
![image](https://github.com/user-attachments/assets/eda40bbb-4995-4d3b-9261-5c4ea4b584b1)


